### PR TITLE
SCALRCORE-11774 Webhooks > TypeError: unsupported operand type(s) for +: 'NoneType' and 'int' (caused by celery upgrade)

### DIFF
--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -47,7 +47,7 @@ def hybrid_to_proto2(message, body):
         'shadow': body.get('shadow'),
         'eta': body.get('eta'),
         'expires': body.get('expires'),
-        'retries': body.get('retries'),
+        'retries': body.get('retries', 0),
         'timelimit': body.get('timelimit', (None, None)),
         'argsrepr': body.get('argsrepr'),
         'kwargsrepr': body.get('kwargsrepr'),


### PR DESCRIPTION
…end from php

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
