### PR TITLE
SCALRCORE-11936 (Celery) Celery: task.get() does not return result (ex. Monitor: Expand info in the log)

### DIFF
--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -295,7 +295,9 @@ class RPCBackend(base.Backend, AsyncBackendMixin):
             return message.payload['task_id']
 
     def revive(self, channel):
-        pass
+        # SCALRCORE-11936 Revive backend consumer
+        if self.result_consumer._consumer:
+            self.result_consumer._consumer.revive(channel)
 
     def reload_task_result(self, task_id):
         raise NotImplementedError(

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -338,6 +338,7 @@ class Consumer(object):
                     blueprint.restart(self)
                     # SCALRCORE-11936 Callback to revive RPC backend consumer
                     if self.app.backend:
+                        info('Reviving backend consumer...')
                         channel = self.app.connection.default_channel
                         self.app.backend.revive(channel)
 

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -336,6 +336,10 @@ class Consumer(object):
                         self.on_connection_error_before_connected(exc)
                     self.on_close()
                     blueprint.restart(self)
+                    # SCALRCORE-11936 Callback to revive RPC backend consumer
+                    if self.app.backend:
+                        channel = self.app.connection.default_channel
+                        self.app.backend.revive(channel)
 
     def on_connection_error_before_connected(self, exc):
         error(CONNECTION_ERROR, self.conninfo.as_uri(), exc,

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -292,6 +292,7 @@ class test_Heart:
 
         with patch('celery.worker.heartbeat.Heart') as hcls:
             h = Heart(c, False, 20)
+            h.app.backend = None
             assert h.enabled
             assert h.heartbeat_interval == 20
             assert c.heart is None

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -230,6 +230,8 @@ class test_Consumer:
         return se
 
     def test_collects_at_restart(self):
+        conn_mock = self.app.connection = Mock()
+        conn_mock.default_connection = None
         c = self.get_consumer()
         c.connection.collect.side_effect = MemoryError()
         c.blueprint.start.side_effect = socket.error()

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -230,8 +230,7 @@ class test_Consumer:
         return se
 
     def test_collects_at_restart(self):
-        conn_mock = self.app.connection = Mock()
-        conn_mock.default_connection = None
+        self.app.backend = None
         c = self.get_consumer()
         c.connection.collect.side_effect = MemoryError()
         c.blueprint.start.side_effect = socket.error()

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -292,7 +292,6 @@ class test_Heart:
 
         with patch('celery.worker.heartbeat.Heart') as hcls:
             h = Heart(c, False, 20)
-            h.blueprint.app.backend = None
             assert h.enabled
             assert h.heartbeat_interval == 20
             assert c.heart is None

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -292,7 +292,7 @@ class test_Heart:
 
         with patch('celery.worker.heartbeat.Heart') as hcls:
             h = Heart(c, False, 20)
-            h.app.backend = None
+            h.blueprint.app.backend = None
             assert h.enabled
             assert h.heartbeat_interval == 20
             assert c.heart is None

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -286,7 +286,7 @@ class test_Consumer(ConsumerCase):
             c.timer and c.timer.stop()
 
     def test_start_connection_error(self):
-        self.app.backend.result_consumer._consumer = None
+        self.app.backend.result_consumer.revive = Mock()
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))
         c.connection_errors = (KeyError,)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -286,6 +286,7 @@ class test_Consumer(ConsumerCase):
             c.timer and c.timer.stop()
 
     def test_start_connection_error(self):
+        self.app.connection.default_channel = None
         self.app.backend.result_consumer = Mock()
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -286,6 +286,7 @@ class test_Consumer(ConsumerCase):
             c.timer and c.timer.stop()
 
     def test_start_connection_error(self):
+        self.app.backend = None
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))
         c.connection_errors = (KeyError,)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -288,7 +288,7 @@ class test_Consumer(ConsumerCase):
     def test_start_connection_error(self):
         conn_mock = self.app.connection = Mock()
         conn_mock.default_channel = None
-        self.app.backend.result_consumer = Mock()
+        self.app.backend.revive = Mock()
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))
         c.connection_errors = (KeyError,)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -286,7 +286,8 @@ class test_Consumer(ConsumerCase):
             c.timer and c.timer.stop()
 
     def test_start_connection_error(self):
-        self.app.connection.default_channel = None
+        conn_mock = self.app.connection = Mock()
+        conn_mock.default_channel = None
         self.app.backend.result_consumer = Mock()
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -286,7 +286,7 @@ class test_Consumer(ConsumerCase):
             c.timer and c.timer.stop()
 
     def test_start_connection_error(self):
-        self.app.backend.result_consumer.revive = Mock()
+        self.app.backend.result_consumer = Mock()
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))
         c.connection_errors = (KeyError,)

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -286,7 +286,7 @@ class test_Consumer(ConsumerCase):
             c.timer and c.timer.stop()
 
     def test_start_connection_error(self):
-        self.app.backend = None
+        self.app.backend.result_consumer._consumer = None
         c = self.NoopConsumer(task_events=False, pool=BasePool())
         c.loop.on_nth_call_do_raise(KeyError('foo'), SyntaxError('bar'))
         c.connection_errors = (KeyError,)


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

The changes fix RPC backend consumer reviving after reconnection to RabbitMQ 

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
