### PR TITLE
SCALRCORE-13886 AttributeError: 'function' object has no attribute 'default_channel'

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -339,7 +339,7 @@ class Consumer(object):
                     # SCALRCORE-11936 Callback to revive RPC backend consumer
                     if self.app.backend:
                         info('Reviving backend consumer...')
-                        channel = self.app.connection.default_channel
+                        channel = self.conninfo.default_channel
                         self.app.backend.revive(channel)
 
     def on_connection_error_before_connected(self, exc):


### PR DESCRIPTION
The problem here was that `self.app.connection` is a function which returns a connection. There is a separate function which returns a connection for consuming (`self.app.connection_for_read()`) which we call in `__init__` and save the result in `self`.

This fixes the exception in the ticket.
