### PR TITLE
SCALRCORE-17315 [celery] Celery > Couldn't ack 424, reason:BrokenPipeError(32, 'Broken pipe')

### DIFF
--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -233,6 +233,9 @@ class Consumer(object):
             while self._pending_operations:
                 try:
                     self._pending_operations.pop()()
+                except BrokenPipeError:
+                    # re-raise this error to allow a consumer to reconnect
+                    raise
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.exception('Pending callback raised: %r', exc)
 

--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -33,11 +33,25 @@ def _quick_drain(connection, timeout=0.1):
 
 
 def _enable_amqheartbeats(timer, connection, rate=2.0):
-    if connection:
-        tick = connection.heartbeat_check
-        heartbeat = connection.get_heartbeat_interval()  # negotiated
-        if heartbeat and connection.supports_heartbeats:
-            timer.call_repeatedly(heartbeat / rate, tick, (rate,))
+    heartbeat_error = [None]
+
+    if not connection:
+        return heartbeat_error
+
+    heartbeat = connection.get_heartbeat_interval()  # negotiated
+    if not (heartbeat and connection.supports_heartbeats):
+        return heartbeat_error
+
+    def tick(rate):
+        try:
+            connection.heartbeat_check(rate)
+        except Exception as e:
+            # heartbeat_error is passed by reference can be updated
+            # no append here list should be fixed size=1
+            heartbeat_error[0] = e
+
+    timer.call_repeatedly(heartbeat / rate, tick, (rate,))
+    return heartbeat_error
 
 
 def asynloop(obj, connection, consumer, blueprint, hub, qos,
@@ -49,8 +63,7 @@ def asynloop(obj, connection, consumer, blueprint, hub, qos,
 
     on_task_received = obj.create_task_handler()
 
-    _enable_amqheartbeats(hub.timer, connection, rate=hbrate)
-
+    heartbeat_error = _enable_amqheartbeats(hub.timer, connection, rate=hbrate)
     consumer.on_message = on_task_received
     obj.controller.register_with_event_loop(hub)
     obj.register_with_event_loop(hub)
@@ -88,6 +101,8 @@ def asynloop(obj, connection, consumer, blueprint, hub, qos,
     try:
         while blueprint.state == RUN and obj.connection:
             state.maybe_shutdown()
+            if heartbeat_error[0] is not None:
+                raise heartbeat_error[0]
 
             # We only update QoS when there's no more messages to read.
             # This groups together qos calls, and makes sure that remote
@@ -113,8 +128,9 @@ def synloop(obj, connection, consumer, blueprint, hub, qos,
     RUN = bootsteps.RUN
     on_task_received = obj.create_task_handler()
     perform_pending_operations = obj.perform_pending_operations
+    heartbeat_error = [None]
     if getattr(obj.pool, 'is_green', False):
-        _enable_amqheartbeats(obj.timer, connection, rate=hbrate)
+        heartbeat_error = _enable_amqheartbeats(obj.timer, connection, rate=hbrate)
     consumer.on_message = on_task_received
     consumer.consume()
 
@@ -122,11 +138,18 @@ def synloop(obj, connection, consumer, blueprint, hub, qos,
 
     while blueprint.state == RUN and obj.connection:
         state.maybe_shutdown()
+        if heartbeat_error[0] is not None:
+            raise heartbeat_error[0]
+
         if qos.prev != qos.value:
             qos.update()
         try:
             perform_pending_operations()
             connection.drain_events(timeout=2.0)
+        except BrokenPipeError:
+            logger.warning("Broker unexpectedly closed TCP connection")
+            connection.close()
+            raise
         except socket.timeout:
             pass
         except socket.error:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
